### PR TITLE
ember-select-light integration

### DIFF
--- a/addon/templates/components/select-box.hbs
+++ b/addon/templates/components/select-box.hbs
@@ -5,18 +5,17 @@
 {{/if}}
 <div class="select-box__wrapper">
 	{{#if nativeSelect}}
-		<select name="{{selectId}}" id="{{selectId}}" class="mdl-textfield__input" onchange={{action "selectItem" value="target.value"}}>
-			{{#if placeholder}}
-				<option value="" selected>{{placeholder}}</option>
-			{{/if}}
-			{{#each options as |option index|}}
-				{{#if isDeepOptions}}
-					<option value={{get option valueKey}} selected={{eq selected (get option valueKey)}} data-test-id={{concat "sbNativeDeepOption" index}}>{{get option displayKey}}</option>
-				{{else}}
-					<option value={{option}} selected={{eq selected option}} data-test-id={{concat "sbNativeFlatOption" index}}>{{option}}</option>
-				{{/if}}
-			{{/each}}
-		</select>
+		{{select-light
+			name=selectId
+			id=selectId
+			class="mdl-textfield__input"
+			placeholder=placeholder
+			value=selected
+			valueKey=valueKey
+			displayKey=displayKey
+			options=options
+			change=(action "selectItem" value="target.value")
+			}}
 		<i class="icon-expand"></i>
 	{{else}}
 		<i class="icon-expand"></i>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-mocha": "^0.12.0",
     "ember-resolver": "^2.0.3",
     "ember-responsive": "^2.0.3",
+    "ember-select-light": "^1.1.0",
     "ember-source": "^2.11.0",
     "ember-truth-helpers": "^1.3.0",
     "ember-welcome-page": "^2.0.2",

--- a/tests/integration/components/select-box-test.js
+++ b/tests/integration/components/select-box-test.js
@@ -32,7 +32,7 @@ describe('Integration | Component | select box', function () {
         this.set('valueKey', 'value');
         this.set('options', [{value:'1', display: 'first'}, {value:'2', display: 'second'}, {value:'3', display: 'third'}, {value:'4', display: 'fourth'}]);
         this.render(hbs `{{select-box options=options displayKey=displayKey valueKey=valueKey nativeSelect=true}}`);
-        expect(findAll('[data-test-id^="sbNativeDeepOption"]')).to.have.lengthOf(4);
+        expect(findAll('select option')).to.have.lengthOf(4);
     });
     it('handles custom flat options and filterable options', function () {
         this.set('options', ['1', '2', '3', '4']);
@@ -42,7 +42,7 @@ describe('Integration | Component | select box', function () {
     it('handles native flat options', function () {
         this.set('options', ['1', '2', '3', '4']);
         this.render(hbs `{{select-box options=options nativeSelect=true}}`);
-        expect(findAll('[data-test-id^="sbNativeFlatOption"]')).to.have.lengthOf(4);
+        expect(findAll('select option')).to.have.lengthOf(4);
     });
     it('displays correct selected value for custom deep options', function () {
         this.set('displayKey', 'display');
@@ -65,7 +65,7 @@ describe('Integration | Component | select box', function () {
         this.set('selected', '3');
         this.render(hbs `{{select-box options=options selected=selected valueKey=valueKey displayKey=displayKey nativeSelect=true}}`);
         expect(find('select').value).to.eq('3');
-        expect(this.$('[data-test-id^="sbNativeDeepOption"]:selected').text()).to.eq('third');
+        expect(this.$('select option:selected').text().trim()).to.eq('third');
     }); 
     it('binds correct selected value for native flat options', function () {
         this.set('options', ['1', '2', '3', '4']);

--- a/tests/integration/components/select-box-test.js
+++ b/tests/integration/components/select-box-test.js
@@ -31,8 +31,8 @@ describe('Integration | Component | select box', function () {
         this.set('displayKey', 'display');
         this.set('valueKey', 'value');
         this.set('options', [{value:'1', display: 'first'}, {value:'2', display: 'second'}, {value:'3', display: 'third'}, {value:'4', display: 'fourth'}]);
-        this.render(hbs `{{select-box options=options displayKey=displayKey valueKey=valueKey nativeSelect=true}}`);
-        expect(findAll('select option')).to.have.lengthOf(4);
+        this.render(hbs `{{select-box selectId="sbNativeDeep" options=options displayKey=displayKey valueKey=valueKey nativeSelect=true}}`);
+        expect(findAll('#sbNativeDeep option')).to.have.lengthOf(4);
     });
     it('handles custom flat options and filterable options', function () {
         this.set('options', ['1', '2', '3', '4']);
@@ -41,8 +41,8 @@ describe('Integration | Component | select box', function () {
     });
     it('handles native flat options', function () {
         this.set('options', ['1', '2', '3', '4']);
-        this.render(hbs `{{select-box options=options nativeSelect=true}}`);
-        expect(findAll('select option')).to.have.lengthOf(4);
+        this.render(hbs `{{select-box selectId="sbNativeFlat" options=options nativeSelect=true}}`);
+        expect(findAll('#sbNativeFlat option')).to.have.lengthOf(4);
     });
     it('displays correct selected value for custom deep options', function () {
         this.set('displayKey', 'display');
@@ -63,15 +63,15 @@ describe('Integration | Component | select box', function () {
         this.set('valueKey', 'value');
         this.set('options', [{value:'1', display: 'first'}, {value:'2', display: 'second'}, {value:'3', display: 'third'}, {value:'4', display: 'fourth'}]);
         this.set('selected', '3');
-        this.render(hbs `{{select-box options=options selected=selected valueKey=valueKey displayKey=displayKey nativeSelect=true}}`);
-        expect(find('select').value).to.eq('3');
-        expect(this.$('select option:selected').text().trim()).to.eq('third');
+        this.render(hbs `{{select-box selectId="sbNativeDeep" options=options selected=selected valueKey=valueKey displayKey=displayKey nativeSelect=true}}`);
+        expect(find('#sbNativeDeep').value).to.eq('3');
+        expect(this.$('#sbNativeDeep option:selected').text().trim()).to.eq('third');
     }); 
     it('binds correct selected value for native flat options', function () {
         this.set('options', ['1', '2', '3', '4']);
         this.set('selected', '3');
-        this.render(hbs `{{select-box options=options selected=selected nativeSelect=true}}`);
-        expect(find('select').value).to.eq('3');
+        this.render(hbs `{{select-box selectId="sbNativeFlat" options=options selected=selected nativeSelect=true}}`);
+        expect(find('#sbNativeFlat').value).to.eq('3');
     });
     it('clears query string on click of close icon', function () {
         this.set('media', {isDesktop: false});


### PR DESCRIPTION
@abdulmhamid @pixelhandler replacing native select with `ember-select-light` for proper dog fooding. Open to feedback.